### PR TITLE
Fix hook template where classname has '.' in it.

### DIFF
--- a/app.js
+++ b/app.js
@@ -144,7 +144,7 @@ var classname = "{className}";
 var classmethod = "{classMethod}";
 var methodsignature = "{methodSignature}";
 try {
-  var hook = eval('ObjC.classes.' + classname + '["' + classmethod + '"]');
+  var hook = eval('ObjC.classes["' + classname + '"]["' + classmethod + '"]');
 
   Interceptor.attach(hook.implementation, {
     onEnter: function (args) {
@@ -212,7 +212,7 @@ var classname = "{className}";
 var classmethod = "{classMethod}";
 var methodsignature = "{methodSignature}";
 try {
-  var hook = eval('ObjC.classes.' + classname + '["' + classmethod + '"]');
+  var hook = eval('ObjC.classes["' + classname + '"]["' + classmethod + '"]');
  
   //{methodSignature}
   Interceptor.attach(hook.implementation, {


### PR DESCRIPTION
For example, if the classname is `Slack.FeatureFlagManager`, the iOS hook template currently fails. Using the [ ] notation fixes this.