### PR TITLE
feats: add port argument

### DIFF
--- a/rms.js
+++ b/rms.js
@@ -87,7 +87,9 @@ Server startup
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 */
 
-server.listen(5000, () => {
+const PORT_INTERFACE = process.argv.includes('--port') ? process.argv[process.argv.indexOf('--port') + 1] : 5000;
+
+server.listen(PORT_INTERFACE, () => {
 
   console.log("")
   console.log("_________________________________________________________")
@@ -98,7 +100,7 @@ server.listen(5000, () => {
   console.log("_________________________________________________________")
   console.log("")
 
-  console.log("Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)");
+  console.log(`Running on http://127.0.0.1:${PORT_INTERFACE}/ (Press CTRL+C to quit)`);
   
 });
 


### PR DESCRIPTION
on MacOS Ventura (13.5.1), Control Center use the port 5000 by default, so it's impossible to run RMS.

![image](https://github.com/m0bilesecurity/RMS-Runtime-Mobile-Security/assets/12927290/4e850293-340d-4391-aa89-67526ba01554)
