### PR TITLE
Fixes #126 - PayloadTooLargeError on big Frida script

### DIFF
--- a/rms.js
+++ b/rms.js
@@ -62,8 +62,10 @@ var methods_hooked_and_executed = []
 
 //app instance
 const app = express();
+
 // server instance
 const server = http.createServer(app);
+
 // socket listen
 const io=socket_io(server);
 
@@ -71,10 +73,12 @@ const io=socket_io(server);
 app.set('socket_io', io);
 
 //express post config
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.urlencoded({ extended: true, limit: '50mb' }));
 app.use(bodyParser.json());
+
 //express static path
-app.use(express.static(STATIC_PATH))
+app.use(express.static(STATIC_PATH));
+
 //nunjucks config
 nunjucks.configure(TEMPLATE_PATH, {
     autoescape: true,


### PR DESCRIPTION
As described in issue #126, when a big frida script with a lot of code is attached/spawned to/with an application, rms throws an exception `PayloadTooLargeError: request entity too large`. 

This is due to the HTTP request body being too large because of the large amount of code. Changing the length of the POST body content in this case (to `50mb` - bit overkill but doesn't hurt to have it this large) fixes the issue.  