### PR TITLE
fix: prevent open redirect via redirect query parameter

### DIFF
--- a/rms.js
+++ b/rms.js
@@ -1357,6 +1357,10 @@ app.get("/reset_console_logs", async function(req, res){
 
   redirect_url = req.query.redirect
   //auto redirect the user to the console output page
+  // Prevent open redirect: only allow relative paths
+  if (!redirect_url || redirect_url.startsWith('//') || redirect_url.includes('://')) {
+    redirect_url = '/';
+  }
   return res.redirect(redirect_url);
 })
 /* 


### PR DESCRIPTION
## Summary

Prevent open redirect by validating the `redirect` query parameter before redirecting.

## Problem

The redirect handler passes the user-supplied `redirect` query parameter directly to `res.redirect` without validation:

```javascript
redirect_url = req.query.redirect
return res.redirect(redirect_url);
```

An attacker can redirect users to malicious external sites:
```
http://rms-server:5000/endpoint?redirect=https://evil.com/phish
```

## Fix

Validate that the redirect URL is a relative path by rejecting URLs starting with `//` or containing `://`:

```javascript
if (!redirect_url || redirect_url.startsWith('//') || redirect_url.includes('://')) {
    redirect_url = '/';
}
```

## Impact

- **Type**: Open Redirect (CWE-601)
- **Risk**: Phishing via trusted domain redirect
- **OWASP**: A01:2021 — Broken Access Control