### PR TITLE
fix: bump frida-java-bridge to 7.0.13 for Android 15+ compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "express": "^5.1.0",
         "frida": "^17.5.1",
         "frida-fs": "^7.0.0",
-        "frida-java-bridge": "^7.0.10",
+        "frida-java-bridge": "^7.0.13",
         "frida-objc-bridge": "^8.0.5",
         "node-datetime": "^2.1.2",
         "nunjucks": "^3.2.4",
@@ -1023,10 +1023,9 @@
       "integrity": "sha512-95m7LCjuFMZObrR/37tlEUHAKC0UP82vWBtcaFntUSFr5MuqhoZG6FDCXKl58FhTf0SwOCYvwctCYPLV3/pHgw=="
     },
     "node_modules/frida-java-bridge": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/frida-java-bridge/-/frida-java-bridge-7.0.10.tgz",
-      "integrity": "sha512-AtjgAHE7a2wV6M/8tZvjVqda0T8YGmSoXqkbD0r1Eq6XTFDKYbClKbZqMYHpI9OjxtkIx+xPqkHWWE3+0fDH7w==",
-      "license": "LGPL-2.0 WITH WxWindows-exception-3.1"
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/frida-java-bridge/-/frida-java-bridge-7.0.13.tgz",
+      "integrity": "sha512-YSyKjxbxKnSi3KSUy9vciOvTOuq0RRh9dkxzkQVEdfIIZlw20zE8D3Cq9eL2FDqUVj4YKas6Wf09kCjL5zbffg=="
     },
     "node_modules/frida-objc-bridge": {
       "version": "8.0.5",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "express": "^5.1.0",
     "frida": "^17.5.1",
     "frida-fs": "^7.0.0",
-    "frida-java-bridge": "^7.0.10",
+    "frida-java-bridge": "^7.0.13",
     "frida-objc-bridge": "^8.0.5",
     "node-datetime": "^2.1.2",
     "nunjucks": "^3.2.4",


### PR DESCRIPTION
## Fix: bump frida-java-bridge to 7.0.13 for Android 15+ compatibility

### Problem

RMS fails on Android 15+ with:

```
Error: Unable to find copied methods in java/lang/Thread; please file a bug
```

This is caused by `frida-java-bridge@7.0.10` not supporting ART changes introduced in Android 15. The same issue was reported in objection ([#800](https://github.com/sensepost/objection/issues/800)) and fixed by bumping to `7.0.13`.

Upstream frida bug: [frida/frida#3713](https://github.com/frida/frida/issues/3713)

### Changes

- `package.json`: bump `frida-java-bridge` from `^7.0.10` to `^7.0.13`
- `agent/compiled_RMS_core.js`: rebuilt with updated dependency

### Tested on

- OnePlus 10T, Android 15, rooted (Magisk)
- RMS 1.5.24